### PR TITLE
Add tag management CRUD tools

### DIFF
--- a/readwise_mcp/tools/readwise/common.py
+++ b/readwise_mcp/tools/readwise/common.py
@@ -34,16 +34,36 @@ def to_book_category(category_str: str) -> BookCategory:
         raise ValueError(f"Invalid category: {category_str}. Valid categories are: {BookCategory.get_valid_values()}")
 
 
-async def get_data(api_key: str, url: str, params: Optional[Dict] = None, retries: int = 3) -> List | Dict:
-    """Get data from the API."""
+async def _make_request(
+    api_key: str,
+    method: str,
+    url: str,
+    expected_statuses: tuple,
+    params: Optional[Dict] = None,
+    body: Optional[Dict] = None,
+    retries: int = 3,
+) -> Optional[Dict | List]:
+    """Make an HTTP request with retry and rate-limit handling.
+
+    Args:
+        api_key: Readwise API key.
+        method: HTTP method (GET, POST, PATCH, DELETE).
+        url: Full API URL.
+        expected_statuses: Tuple of HTTP status codes that indicate success.
+        params: Optional query parameters (for GET requests).
+        body: Optional JSON body (for POST/PATCH requests).
+        retries: Number of retry attempts.
+
+    Returns:
+        Parsed JSON response, or None for responses with no body (e.g. 204).
+    """
 
     for _ in range(retries):
         async with httpx.AsyncClient() as client:
             try:
-                response = await client.get(url, headers={"Authorization": f"Token {api_key}"}, params=params)
-                # Check whether we got a 429 HTTP error
+                headers = {"Authorization": f"Token {api_key}"}
+                response = await client.request(method, url, headers=headers, params=params, json=body)
                 if response.status_code == 429:
-                    # Extract the Retry-After header
                     retry_after = response.headers.get("Retry-After")
                     if retry_after:
                         logging.info(f"Rate limit exceeded. Retrying in {retry_after} seconds.")
@@ -53,11 +73,33 @@ async def get_data(api_key: str, url: str, params: Optional[Dict] = None, retrie
                         logging.info("Rate limit exceeded. Retrying in 1 second.")
                         await asyncio.sleep(1)
                         continue
-                if response.status_code != 200:
-                    raise Exception(f"Failed to get data from {url}: {response.status_code} {response.text}")
+                if response.status_code not in expected_statuses:
+                    raise Exception(f"Failed to {method} {url}: {response.status_code} {response.text}")
+                if response.status_code == 204:
+                    return None
                 return response.json()
             except Exception as e:
-                logging.error(f"Error getting data from {url}: {e}")
+                logging.error(f"Error during {method} {url}: {e}")
                 continue
 
-    raise Exception(f"Failed to get data from {url} with params {params} after {retries} retries")
+    raise Exception(f"Failed to {method} {url} after {retries} retries")
+
+
+async def get_data(api_key: str, url: str, params: Optional[Dict] = None, retries: int = 3) -> List | Dict:
+    """Get data from the API."""
+    return await _make_request(api_key, "GET", url, (200,), params=params, retries=retries)
+
+
+async def post_data(api_key: str, url: str, body: Dict, retries: int = 3) -> Dict:
+    """Post data to the API."""
+    return await _make_request(api_key, "POST", url, (200, 201), body=body, retries=retries)
+
+
+async def patch_data(api_key: str, url: str, body: Dict, retries: int = 3) -> Dict:
+    """Patch data on the API."""
+    return await _make_request(api_key, "PATCH", url, (200,), body=body, retries=retries)
+
+
+async def delete_data(api_key: str, url: str, retries: int = 3) -> None:
+    """Delete data from the API."""
+    await _make_request(api_key, "DELETE", url, (204,), retries=retries)

--- a/readwise_mcp/tools/readwise/manage_tags.py
+++ b/readwise_mcp/tools/readwise/manage_tags.py
@@ -1,0 +1,90 @@
+# Standard Library
+from typing import List, Literal, Optional
+
+# Internal Libraries
+from readwise_mcp.tools.readwise.common import (
+    READWISE_API_URL,
+    delete_data,
+    get_data,
+    patch_data,
+    post_data,
+)
+from readwise_mcp.types.tag import Tag
+
+EntityType = Literal["highlights", "books"]
+
+
+def _tags_url(entity_type: EntityType, entity_id: int, tag_id: Optional[int] = None) -> str:
+    """Build the tags URL for a given entity."""
+    base = f"{READWISE_API_URL}/{entity_type}/{entity_id}/tags"
+    if tag_id is not None:
+        return f"{base}/{tag_id}"
+    return base
+
+
+async def get_tags(api_key: str, entity_type: EntityType, entity_id: int) -> List[Tag]:
+    """Get all tags for a highlight or book.
+
+    The book tags endpoint returns a plain list, while the highlight tags
+    endpoint returns a paginated response with a ``results`` key.
+
+    Args:
+        api_key: Readwise API key.
+        entity_type: Either "highlights" or "books".
+        entity_id: The ID of the highlight or book.
+
+    Returns:
+        List of Tag objects.
+    """
+    url = _tags_url(entity_type, entity_id)
+    data = await get_data(api_key, url)
+    tag_list = data["results"] if isinstance(data, dict) else data
+    return [Tag(**tag) for tag in tag_list]
+
+
+async def add_tag(api_key: str, entity_type: EntityType, entity_id: int, tag_name: str) -> Tag:
+    """Add a tag to a highlight or book.
+
+    Args:
+        api_key: Readwise API key.
+        entity_type: Either "highlights" or "books".
+        entity_id: The ID of the highlight or book.
+        tag_name: The name of the tag to add.
+
+    Returns:
+        The created Tag object.
+    """
+    url = _tags_url(entity_type, entity_id)
+    data = await post_data(api_key, url, {"name": tag_name})
+    return Tag(**data)
+
+
+async def update_tag(api_key: str, entity_type: EntityType, entity_id: int, tag_id: int, new_name: str) -> Tag:
+    """Rename a tag on a highlight or book.
+
+    Args:
+        api_key: Readwise API key.
+        entity_type: Either "highlights" or "books".
+        entity_id: The ID of the highlight or book.
+        tag_id: The ID of the tag to rename.
+        new_name: The new name for the tag.
+
+    Returns:
+        The updated Tag object.
+    """
+    url = _tags_url(entity_type, entity_id, tag_id)
+    data = await patch_data(api_key, url, {"name": new_name})
+    return Tag(**data)
+
+
+async def delete_tag(api_key: str, entity_type: EntityType, entity_id: int, tag_id: int) -> None:
+    """Remove a tag from a highlight or book.
+
+    Args:
+        api_key: Readwise API key.
+        entity_type: Either "highlights" or "books".
+        entity_id: The ID of the highlight or book.
+        tag_id: The ID of the tag to remove.
+    """
+    url = _tags_url(entity_type, entity_id, tag_id)
+    await delete_data(api_key, url)

--- a/server.py
+++ b/server.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 import os
 from datetime import date
-from typing import Dict, List, Optional
+from typing import Dict, List, Literal, Optional
 
 # Third Party
 from dotenv import load_dotenv
@@ -18,8 +18,15 @@ from readwise_mcp.tools.readwise.get_highlights import (
     get_highlight_by_document_id,
     get_highlights_by_filters,
 )
+from readwise_mcp.tools.readwise.manage_tags import (
+    add_tag,
+    delete_tag,
+    get_tags,
+    update_tag,
+)
 from readwise_mcp.types.book import Book
 from readwise_mcp.types.highlight import Highlight
+from readwise_mcp.types.tag import Tag
 from readwise_mcp.utils.duration import parse_duration
 
 load_dotenv()
@@ -168,6 +175,80 @@ async def get_readwise_highlights_by_filters(
 
     highlights = await get_highlights_by_filters(READWISE_API_KEY, from_date, to_date, tag_names)
     return highlights
+
+
+@mcp.tool()
+async def get_readwise_tags(
+    entity_type: Literal["highlights", "books"],
+    entity_id: int,
+) -> List[Tag]:
+    """List all tags on a Readwise highlight or book.
+
+    Args:
+        entity_type (Literal["highlights", "books"]): Whether to get tags from a highlight or a book.
+        entity_id (int): The ID of the highlight or book.
+
+    Returns:
+        List[Tag]: A list of Tag objects for the specified entity.
+    """
+    return await get_tags(READWISE_API_KEY, entity_type, entity_id)
+
+
+@mcp.tool()
+async def add_readwise_tag(
+    entity_type: Literal["highlights", "books"],
+    entity_id: int,
+    tag_name: str,
+) -> Tag:
+    """Add a tag to a Readwise highlight or book.
+
+    Args:
+        entity_type (Literal["highlights", "books"]): Whether to tag a highlight or a book.
+        entity_id (int): The ID of the highlight or book.
+        tag_name (str): The name of the tag to add.
+            Max 127 characters for highlights, 512 for books.
+
+    Returns:
+        Tag: The created Tag object.
+    """
+    return await add_tag(READWISE_API_KEY, entity_type, entity_id, tag_name)
+
+
+@mcp.tool()
+async def update_readwise_tag(
+    entity_type: Literal["highlights", "books"],
+    entity_id: int,
+    tag_id: int,
+    new_tag_name: str,
+) -> Tag:
+    """Rename a tag on a Readwise highlight or book.
+
+    Args:
+        entity_type (Literal["highlights", "books"]): Whether the tag belongs to a highlight or a book.
+        entity_id (int): The ID of the highlight or book.
+        tag_id (int): The ID of the tag to rename.
+        new_tag_name (str): The new name for the tag.
+
+    Returns:
+        Tag: The updated Tag object.
+    """
+    return await update_tag(READWISE_API_KEY, entity_type, entity_id, tag_id, new_tag_name)
+
+
+@mcp.tool()
+async def delete_readwise_tag(
+    entity_type: Literal["highlights", "books"],
+    entity_id: int,
+    tag_id: int,
+) -> None:
+    """Remove a tag from a Readwise highlight or book.
+
+    Args:
+        entity_type (Literal["highlights", "books"]): Whether the tag belongs to a highlight or a book.
+        entity_id (int): The ID of the highlight or book.
+        tag_id (int): The ID of the tag to remove.
+    """
+    await delete_tag(READWISE_API_KEY, entity_type, entity_id, tag_id)
 
 
 # Add a dynamic greeting resource

--- a/tests/readwise_mcp/tools/readwise/test_common.py
+++ b/tests/readwise_mcp/tools/readwise/test_common.py
@@ -29,17 +29,19 @@ async def test_get_data_success():
     mock_response = httpx.Response(200, json={"results": [{"id": 1}]})
     with patch("readwise_mcp.tools.readwise.common.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
-        mock_client.get.return_value = mock_response
+        mock_client.request.return_value = mock_response
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await get_data("fake-key", "https://readwise.io/api/v2/books/", {"page_size": 50})
 
     assert result == {"results": [{"id": 1}]}
-    mock_client.get.assert_called_once_with(
+    mock_client.request.assert_called_once_with(
+        "GET",
         "https://readwise.io/api/v2/books/",
         headers={"Authorization": "Token fake-key"},
         params={"page_size": 50},
+        json=None,
     )
 
 
@@ -50,14 +52,14 @@ async def test_get_data_rate_limit_then_success():
 
     with patch("readwise_mcp.tools.readwise.common.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
-        mock_client.get.side_effect = [rate_limit_response, success_response]
+        mock_client.request.side_effect = [rate_limit_response, success_response]
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
         result = await get_data("fake-key", "https://readwise.io/api/v2/books/")
 
     assert result == {"results": []}
-    assert mock_client.get.call_count == 2
+    assert mock_client.request.call_count == 2
 
 
 @pytest.mark.asyncio
@@ -67,7 +69,7 @@ async def test_get_data_rate_limit_no_retry_after_header():
 
     with patch("readwise_mcp.tools.readwise.common.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
-        mock_client.get.side_effect = [rate_limit_response, success_response]
+        mock_client.request.side_effect = [rate_limit_response, success_response]
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
@@ -82,11 +84,11 @@ async def test_get_data_non_200_raises():
 
     with patch("readwise_mcp.tools.readwise.common.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
-        mock_client.get.return_value = error_response
+        mock_client.request.return_value = error_response
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        with pytest.raises(Exception, match="Failed to get data"):
+        with pytest.raises(Exception, match="Failed to GET"):
             await get_data("fake-key", "https://readwise.io/api/v2/books/", retries=1)
 
 
@@ -96,9 +98,9 @@ async def test_get_data_retries_exhausted():
 
     with patch("readwise_mcp.tools.readwise.common.httpx.AsyncClient") as mock_client_cls:
         mock_client = AsyncMock()
-        mock_client.get.return_value = error_response
+        mock_client.request.return_value = error_response
         mock_client_cls.return_value.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client_cls.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        with pytest.raises(Exception, match="Failed to get data.*after 2 retries"):
+        with pytest.raises(Exception, match="Failed to GET.*after 2 retries"):
             await get_data("fake-key", "https://readwise.io/api/v2/books/", retries=2)

--- a/tests/readwise_mcp/tools/readwise/test_get_document_unit.py
+++ b/tests/readwise_mcp/tools/readwise/test_get_document_unit.py
@@ -121,9 +121,7 @@ async def test_list_documents_by_filters_by_category():
 async def test_list_documents_by_filters_by_date_range():
     with patch("readwise_mcp.tools.readwise.get_document.get_data", new_callable=AsyncMock) as mock_get:
         mock_get.return_value = _api_response([SAMPLE_ARTICLE_JSON])
-        result = await list_documents_by_filters(
-            FAKE_API_KEY, from_date=date(2024, 1, 1), to_date=date(2024, 1, 31)
-        )
+        result = await list_documents_by_filters(FAKE_API_KEY, from_date=date(2024, 1, 1), to_date=date(2024, 1, 31))
 
     assert len(result) == 1
     call_params = mock_get.call_args[0][2]

--- a/tests/readwise_mcp/tools/readwise/test_get_highlights_unit.py
+++ b/tests/readwise_mcp/tools/readwise/test_get_highlights_unit.py
@@ -121,9 +121,7 @@ async def test_get_highlights_by_filters_no_filters_raises():
 async def test_get_highlights_by_filters_pagination_with_tags():
     with patch("readwise_mcp.tools.readwise.get_highlights.get_data", new_callable=AsyncMock) as mock_get:
         mock_get.side_effect = [
-            _api_response(
-                [SAMPLE_HIGHLIGHT_NO_TAGS_JSON], next_url="https://readwise.io/api/v2/highlights/?page=2"
-            ),
+            _api_response([SAMPLE_HIGHLIGHT_NO_TAGS_JSON], next_url="https://readwise.io/api/v2/highlights/?page=2"),
             _api_response([SAMPLE_HIGHLIGHT_JSON]),
         ]
         result = await get_highlights_by_filters(

--- a/tests/readwise_mcp/tools/readwise/test_manage_tags.py
+++ b/tests/readwise_mcp/tools/readwise/test_manage_tags.py
@@ -1,0 +1,101 @@
+# Third Party
+import pytest
+import pytest_asyncio
+
+# Internal Libraries
+from readwise_mcp.tools.readwise.get_highlights import get_highlight_by_document_id
+from readwise_mcp.tools.readwise.manage_tags import add_tag, delete_tag, get_tags, update_tag
+from readwise_mcp.types.tag import Tag
+
+# Known document ID used in other integration tests
+TEST_BOOK_ID = 50788861
+
+
+@pytest_asyncio.fixture()
+async def highlight_id(readwise_api_key):
+    """Fetch a real highlight ID from the test book."""
+    highlights = await get_highlight_by_document_id(readwise_api_key, TEST_BOOK_ID)
+    assert highlights, f"No highlights found for book {TEST_BOOK_ID}"
+    return highlights[0].id
+
+
+# --- Book tag tests ---
+
+
+@pytest.mark.asyncio
+async def test_get_tags_for_book(readwise_api_key):
+    """Test listing tags on a book."""
+    tags = await get_tags(readwise_api_key, "books", TEST_BOOK_ID)
+    assert isinstance(tags, list)
+    for tag in tags:
+        assert isinstance(tag, Tag)
+
+
+@pytest.mark.asyncio
+async def test_add_and_delete_tag_on_book(readwise_api_key):
+    """Test adding a tag to a book and then removing it."""
+    tag_name = "mcp-integration-test"
+
+    created_tag = await add_tag(readwise_api_key, "books", TEST_BOOK_ID, tag_name)
+    try:
+        assert isinstance(created_tag, Tag)
+        assert created_tag.name == tag_name
+
+        tags = await get_tags(readwise_api_key, "books", TEST_BOOK_ID)
+        tag_ids = [t.id for t in tags]
+        assert created_tag.id in tag_ids
+    finally:
+        await delete_tag(readwise_api_key, "books", TEST_BOOK_ID, created_tag.id)
+
+    tags_after = await get_tags(readwise_api_key, "books", TEST_BOOK_ID)
+    tag_ids_after = [t.id for t in tags_after]
+    assert created_tag.id not in tag_ids_after
+
+
+@pytest.mark.asyncio
+async def test_update_tag_on_book(readwise_api_key):
+    """Test renaming a tag on a book."""
+    original_name = "mcp-rename-test"
+    new_name = "mcp-renamed-test"
+
+    created_tag = await add_tag(readwise_api_key, "books", TEST_BOOK_ID, original_name)
+    try:
+        updated_tag = await update_tag(readwise_api_key, "books", TEST_BOOK_ID, created_tag.id, new_name)
+        assert isinstance(updated_tag, Tag)
+        assert updated_tag.name == new_name
+        assert updated_tag.id == created_tag.id
+    finally:
+        await delete_tag(readwise_api_key, "books", TEST_BOOK_ID, created_tag.id)
+
+
+# --- Highlight tag tests ---
+
+
+@pytest.mark.asyncio
+async def test_get_tags_for_highlight(readwise_api_key, highlight_id):
+    """Test listing tags on a highlight."""
+    tags = await get_tags(readwise_api_key, "highlights", highlight_id)
+    assert isinstance(tags, list)
+    for tag in tags:
+        assert isinstance(tag, Tag)
+
+
+@pytest.mark.asyncio
+async def test_add_and_delete_tag_on_highlight(readwise_api_key, highlight_id):
+    """Test adding a tag to a highlight and then removing it."""
+    tag_name = "mcp-highlight-test"
+
+    created_tag = await add_tag(readwise_api_key, "highlights", highlight_id, tag_name)
+    try:
+        assert isinstance(created_tag, Tag)
+        assert created_tag.name == tag_name
+
+        tags = await get_tags(readwise_api_key, "highlights", highlight_id)
+        tag_ids = [t.id for t in tags]
+        assert created_tag.id in tag_ids
+    finally:
+        await delete_tag(readwise_api_key, "highlights", highlight_id, created_tag.id)
+
+    tags_after = await get_tags(readwise_api_key, "highlights", highlight_id)
+    tag_ids_after = [t.id for t in tags_after]
+    assert created_tag.id not in tag_ids_after

--- a/tests/readwise_mcp/tools/readwise/test_server_tools.py
+++ b/tests/readwise_mcp/tools/readwise/test_server_tools.py
@@ -14,26 +14,25 @@ from readwise_mcp.types.highlight import Highlight
 async def test_list_documents_rejects_duration_with_date():
     """duration_expression and from_date/to_date are mutually exclusive."""
     # Import inside test to avoid server.py side effects at module level
+    # Internal Libraries
     from server import list_readwise_documents_by_filters
 
     with pytest.raises(ValueError, match="Cannot provide both duration_expression and from_date or to_date"):
-        await list_readwise_documents_by_filters(
-            duration_expression="1w", from_date=date(2024, 1, 1)
-        )
+        await list_readwise_documents_by_filters(duration_expression="1w", from_date=date(2024, 1, 1))
 
 
 @pytest.mark.asyncio
 async def test_list_documents_rejects_duration_with_to_date():
+    # Internal Libraries
     from server import list_readwise_documents_by_filters
 
     with pytest.raises(ValueError, match="Cannot provide both duration_expression and from_date or to_date"):
-        await list_readwise_documents_by_filters(
-            duration_expression="1w", to_date=date(2024, 1, 31)
-        )
+        await list_readwise_documents_by_filters(duration_expression="1w", to_date=date(2024, 1, 31))
 
 
 @pytest.mark.asyncio
 async def test_list_documents_parses_duration():
+    # Internal Libraries
     from server import list_readwise_documents_by_filters
 
     with patch("server.list_documents_by_filters", new_callable=AsyncMock) as mock_list:
@@ -49,6 +48,7 @@ async def test_list_documents_parses_duration():
 
 @pytest.mark.asyncio
 async def test_get_highlights_rejects_empty_document_ids():
+    # Internal Libraries
     from server import get_readwise_highlights_by_document_ids
 
     with pytest.raises(ValueError, match="No document IDs provided"):
@@ -57,23 +57,31 @@ async def test_get_highlights_rejects_empty_document_ids():
 
 @pytest.mark.asyncio
 async def test_get_highlights_by_filters_rejects_duration_with_date():
+    # Internal Libraries
     from server import get_readwise_highlights_by_filters
 
     with pytest.raises(ValueError, match="Cannot provide both duration_expression and from_date or to_date"):
-        await get_readwise_highlights_by_filters(
-            duration_expression="1w", from_date=date(2024, 1, 1)
-        )
+        await get_readwise_highlights_by_filters(duration_expression="1w", from_date=date(2024, 1, 1))
 
 
 @pytest.mark.asyncio
 async def test_get_highlights_concurrent_gather():
     """Highlights for multiple document IDs are fetched concurrently."""
+    # Internal Libraries
     from server import get_readwise_highlights_by_document_ids
 
     highlight_json = {
-        "id": 1, "text": "hi", "note": "", "location": 1, "location_type": "order",
-        "highlighted_at": "2024-01-15T10:00:00Z", "url": None, "color": "yellow",
-        "updated": "2024-01-15T10:00:00Z", "book_id": 101, "tags": [],
+        "id": 1,
+        "text": "hi",
+        "note": "",
+        "location": 1,
+        "location_type": "order",
+        "highlighted_at": "2024-01-15T10:00:00Z",
+        "url": None,
+        "color": "yellow",
+        "updated": "2024-01-15T10:00:00Z",
+        "book_id": 101,
+        "tags": [],
     }
     highlight_json_2 = {**highlight_json, "id": 2, "book_id": 202}
 


### PR DESCRIPTION
## Summary
- Adds 4 new MCP tools (`get_readwise_tags`, `add_readwise_tag`, `update_readwise_tag`, `delete_readwise_tag`) exposing the Readwise tag API for both highlights and books
- Refactors `common.py` to extract a shared `_make_request` helper with retry and rate-limit logic, replacing duplicated code across HTTP methods
- Handles divergent API response formats (paginated dict for highlight tags vs plain list for book tags)

## Test plan
- [x] All 67 tests pass (`make test`), including 5 new integration tests covering book and highlight tag CRUD
- [x] Existing `test_common.py` unit tests updated to match refactored request interface
- [x] `make fmt && make lint` passes with no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)